### PR TITLE
Added type 'json'

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -15,6 +15,7 @@ typecast output plugin for fluentd.
   - time
   - bool
   - array
+  - json
 
 [time_format] format for typecast to time
 

--- a/lib/fluent/plugin/out_typecast.rb
+++ b/lib/fluent/plugin/out_typecast.rb
@@ -17,7 +17,7 @@ class TypecastOutput < Output
   config_param :tag,         :string, default: nil
   config_param :prefix,      :string, default: nil
 
-  ITEM_TYPES = ['string', 'integer', 'float', 'bool', 'time', 'array']
+  ITEM_TYPES = ['json', 'string', 'integer', 'float', 'bool', 'time', 'array']
 
   def configure(conf)
     super
@@ -49,6 +49,8 @@ class TypecastOutput < Output
 
   def cast_proc(key)
     case key
+    when 'json'
+      Proc.new {|value| value.to_json }
     when 'string'
       Proc.new {|value| value.to_s }
     when 'integer'

--- a/test/plugin/test_out_typecast.rb
+++ b/test/plugin/test_out_typecast.rb
@@ -18,7 +18,7 @@ class TestTypecastOutput < Test::Unit::TestCase
     tag = "test.tag"
     prefix = "prefix"
     d = create_driver(DEFAULT_CONFIG + %[
-      item_types test1:integer,test2:string,test3:time,test4:bool
+      item_types test1:integer,test2:string,test3:time,test4:bool,test5:json
       time_format #{time_format}
       tag #{tag}
       prefix #{prefix}
@@ -28,6 +28,7 @@ class TestTypecastOutput < Test::Unit::TestCase
     assert_equal('string', d.item_types['test2'])
     assert_equal('time', d.item_types['test3'])
     assert_equal('bool', d.item_types['test4'])
+    assert_equal('json', d.item_types['test5'])
 
     assert_equal(time_format, d.time_format)
     assert_equal(tag, d.tag)
@@ -69,6 +70,20 @@ class TestTypecastOutput < Test::Unit::TestCase
     end
     record = d.emits[0][2]
     assert_equal(v, record['f'])
+  end
+
+  def test_typecast_json
+    d = create_driver(DEFAULT_CONFIG + %[
+      tag test.tag
+      item_types j:json
+    ])
+    v = {"msg" => "ok"}
+    time = Time.parse('2013-02-12 22:01:15 UTC').to_i
+    d.run do
+      d.emit({'j' => v }, time)
+    end
+    record = d.emits[0][2]
+    assert_equal(v.to_json, record['j'])
   end
 
   def test_prefix

--- a/test/plugin/test_out_typecast.rb
+++ b/test/plugin/test_out_typecast.rb
@@ -78,7 +78,7 @@ class TestTypecastOutput < Test::Unit::TestCase
       item_types j:json
     ])
     v = {"msg" => "ok"}
-    time = Time.parse('2013-02-12 22:01:15 UTC').to_i
+    time = Time.parse('2015-01-19 08:35:15 UTC').to_i
     d.run do
       d.emit({'j' => v }, time)
     end


### PR DESCRIPTION
Now `fluent-plugin-typecast` casts a hash-table to string such as the following.

```console
{"msg":"ok"} # hash
        ↓
'{"msg" => 'ok'}' # string
```

This PR enables a cast such as the following.

```console
{"msg":"ok"} # hash
        ↓
'{"msg":'ok'}' # json-string
```
