### PR TITLE
Support label feature

### DIFF
--- a/lib/fluent/plugin/out_typecast.rb
+++ b/lib/fluent/plugin/out_typecast.rb
@@ -42,7 +42,7 @@ class TypecastOutput < Output
           record[key] = cast_proc.call(record[key])
         end
       end
-      Fluent::Engine.emit(tag, time, record)
+      router.emit(tag, time, record)
     end
     chain.next
   end

--- a/lib/fluent/plugin/out_typecast.rb
+++ b/lib/fluent/plugin/out_typecast.rb
@@ -2,6 +2,11 @@ module Fluent
 class TypecastOutput < Output
   Fluent::Plugin.register_output('typecast', self)
 
+  # Define `router` method of v0.12 to support v0.10.57 or earlier
+  unless method_defined?(:router)
+    define_method("router") { Engine }
+  end
+
   config_param :item_types, default: nil do |value|
     map = value.split(',').map do |type|
       key, type = type.split(/:/)


### PR DESCRIPTION
Fluentd v0.12 supports label feature.
This feature is enabled by using `router.emit` instead of `Engine.emit`.
And I added keeping backward compatibility hack.
